### PR TITLE
URI Mapped responses for mocking

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -2,14 +2,18 @@ plugins {
     id 'java-library'
     id 'maven-publish'
     id 'com.google.cloud.artifactregistry.gradle-plugin' version '2.2.0'
-    id 'com.github.sherter.google-java-format' version '0.9'
+    id "com.diffplug.spotless" version "6.20.0" // formatting for Java 17
 }
 
 repositories {
     mavenCentral()
 }
 
-googleJavaFormat {}
+spotless {
+    java {
+        googleJavaFormat('1.17.0')
+    }
+}
 
 sourceCompatibility = '1.8'
 targetCompatibility = '1.8'

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,1 +1,1 @@
-software_version=3.0.3
+software_version=3.0.4

--- a/src/main/java/com/exclamationlabs/connid/base/connector/test/util/ConnectorMockRestTest.java
+++ b/src/main/java/com/exclamationlabs/connid/base/connector/test/util/ConnectorMockRestTest.java
@@ -180,6 +180,28 @@ public abstract class ConnectorMockRestTest {
     }
   }
 
+  protected void prepareMockResponse(Map<String, String> uriToResponseMap) {
+    try {
+      Mockito.when(this.stubClient.execute(ArgumentMatchers.any(HttpRequestBase.class)))
+          .thenAnswer(invocation -> {
+              HttpRequestBase request = invocation.getArgument(0);
+              String uri = request.getURI().toString();
+              String responseData = uriToResponseMap.getOrDefault(uri, "");
+              
+              // Set up response for this specific URI
+              Mockito.when(this.stubResponseEntity.getContent())
+                  .thenReturn(new ByteArrayInputStream(responseData.getBytes()));
+              Mockito.when(this.stubResponse.getEntity()).thenReturn(this.stubResponseEntity);
+              Mockito.when(this.stubResponse.getStatusLine()).thenReturn(this.stubStatusLine);
+              Mockito.when(this.stubStatusLine.getStatusCode()).thenReturn(200);
+              
+              return this.stubResponse;
+          });
+    } catch (IOException ioe) {
+      handleFailure("IOException occurred during Mock rest execution for URI-specific response", ioe);
+    }
+  }
+
   private boolean checkResponseData(String... responseData) {
     if (responseData == null || responseData.length == 0) {
       Throwable error = new IllegalAccessException("Invalid Null or empty mock response supplied");


### PR DESCRIPTION
Switch google java format to spotless, add URI mapping support for mocked unit tests, bump version to 3.0.4